### PR TITLE
Add exclude paths for Tests directories

### DIFF
--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -115,18 +115,18 @@
         </condition>
     </target>
 
-    <target name="php-lint" depends="get-changeset.php-absolute.newlinesep" if="changeset.php.notempty">
-        <exec executable="sh" failonerror="true">
-            <arg value="-c"/>
-            <arg value="echo '${changeset.php.absolute.newlinesep}' | xargs -n 1 -P 4 php -l 1>/dev/null"/>
-        </exec>
-        <echo message="OK"/>
-    </target>
-
     <target name="get-changeset.without-tests" depends="get-changeset.php-commasep.notests" if="changeset.php.notempty">
         <condition property="changeset.php.absolute.notests.notempty">
             <isset property="changeset.php.absolute.notests"/>
         </condition>
+    </target>
+
+    <target name="php-lint" depends="get-changeset.without-tests" if="changeset.php.absolute.notests.notempty">
+        <exec executable="sh" failonerror="true">
+            <arg value="-c"/>
+            <arg value="echo '${changeset.php.absolute.notests}' | xargs -n 1 -P 4 php -l 1>/dev/null"/>
+        </exec>
+        <echo message="OK"/>
     </target>
 
     <target name="phpmd" depends="get-changeset.without-tests" if="changeset.php.absolute.notests.notempty">

--- a/build.xml
+++ b/build.xml
@@ -9,6 +9,7 @@
         <pathconvert property="changeset.php.raw" pathsep="${line.separator}">
             <fileset dir="src">
                 <include name="**/*.php"/>
+                <exclude name="**/Tests/**"/>
                 <modified/>
             </fileset>
         </pathconvert>
@@ -63,6 +64,7 @@
             <!-- Don't show warnings-->
             <arg value="--warning-severity=0"/>
             <arg value="--extensions=php"/>
+            <arg value="--ignore=*/Tests/*"/>
             <arg path="src"/>
         </exec>
     </target>
@@ -70,7 +72,7 @@
     <target name="phpcpd-ci" description="Find duplicate code using PHPCPD">
         <exec executable="vendor/bin/phpcpd" failonerror="false">
             <arg value="--exclude"/>
-            <arg value="src/Tests/*"/>
+            <arg value="*/Tests/*"/>
             <arg path="src"/>
         </exec>
     </target>

--- a/qa-tools.json
+++ b/qa-tools.json
@@ -24,13 +24,13 @@
 	"enablePhpLint": true,
 	"enablePhpMessDetector": true,
 	"phpMdExcludePatterns": [
-		"src\/Tests\/*"
+		"*\/Tests\/*"
 	],
 	"enablePhpCodeSniffer": true,
 	"phpCodeSnifferCodingStyle": "PSR2",
 	"phpCsExcludeSymfony": true,
 	"phpCsExcludeCustomPatterns": [
-		"src\/Tests\/*"
+		"*\/Tests\/*"
 	],
 	"phpCsExcludePatterns": [
 		"src\/*\/*Bundle\/Resources",
@@ -41,7 +41,7 @@
 	],
 	"enablePhpCopyPasteDetection": true,
 	"phpCpdExcludePatterns": [
-		"src\/Tests\/*"
+		"*\/Tests\/*"
 	],
 	"enablePhpSecurityChecker": false,
 	"phpSrcPath": [


### PR DESCRIPTION
[Ticket #104425778](https://www.pivotaltracker.com/story/show/104425778): Tests and code can be found at various level in the src tree, all tools should be properly configured to run all tests; include all sourcecode files but exclude test files from static analysis.