### PR TITLE
Make Entity string representation less confusing

### DIFF
--- a/src/Surfnet/Conext/EntityVerificationFramework/Value/ConfiguredMetadata.php
+++ b/src/Surfnet/Conext/EntityVerificationFramework/Value/ConfiguredMetadata.php
@@ -30,9 +30,9 @@ class ConfiguredMetadata
     /** @var Url|null */
     private $publishedMetadataUrl;
     /** @var AssertionConsumerServiceList */
-    private $assertionConsumerServices = [];
+    private $assertionConsumerServices;
     /** @var SingleSignOnServiceList */
-    private $singleSignOnServices = [];
+    private $singleSignOnServices;
     /** @var ContactSet */
     private $contacts;
     /** @var MultiLocaleString */

--- a/src/Surfnet/Conext/EntityVerificationFramework/Value/Entity.php
+++ b/src/Surfnet/Conext/EntityVerificationFramework/Value/Entity.php
@@ -83,6 +83,6 @@ final class Entity
 
     public function __toString()
     {
-        return $this->entityId . '[' . $this->entityType . ']';
+        return $this->entityId . ' (' . $this->entityType . ')';
     }
 }

--- a/src/Surfnet/Conext/OperationsSupportBundle/Tests/Repository/JanusConfiguredMetadataRepositoryTest.php
+++ b/src/Surfnet/Conext/OperationsSupportBundle/Tests/Repository/JanusConfiguredMetadataRepositoryTest.php
@@ -314,7 +314,7 @@ class JanusConfiguredMetadataRepositoryTest extends TestCase
      * @test
      * @group metadata
      * @expectedException \Surfnet\Conext\OperationsSupportBundle\Exception\RuntimeException
-     * @expectedExceptionMessage No connection ID is known for entity "https://hu.invalid[saml20-sp]"
+     * @expectedExceptionMessage No connection ID is known for entity "https://hu.invalid (saml20-sp)"
      * @runInSeparateProcess
      */
     public function throws_an_exception_when_fetching_metadata_for_an_entity_that_cannot_be_mapped_to_a_connection_id()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/107193270

During the demo, I noticed the entity type bracket format after the entity ID can be quite confusing: it appears to be part of the entity ID (commonly a URL).

This commit changes the formatting from:

    https://entity.tld/metadata[saml20-sp]

to:

    https://entity.tld/metadata (saml20-sp)

(Also removes unneeded and incorrect initialisation of service lists.)